### PR TITLE
Check folder permission before listing content.

### DIFF
--- a/source/riffle/browser.py
+++ b/source/riffle/browser.py
@@ -67,6 +67,8 @@ class FilesystemBrowser(QtGui.QDialog):
         model = riffle.model.Filesystem(
             path=self._root, parent=self, iconFactory=self._iconFactory
         )
+        model.permission_error.connect(self.on_permission_error)
+
         proxy.setSourceModel(model)
         proxy.setDynamicSortFilter(True)
 
@@ -86,6 +88,14 @@ class FilesystemBrowser(QtGui.QDialog):
         self._footerLayout.addWidget(self._acceptButton)
 
         self.layout().addLayout(self._footerLayout)
+
+    def on_permission_error(self, error):
+        m = QtGui.QMessageBox.warning(self, 
+            "permission problems",
+            error,
+            QMessageBox.Cancel
+        )
+        m.show()
 
     def _postConstruction(self):
         '''Perform post-construction operations.'''

--- a/source/riffle/browser.py
+++ b/source/riffle/browser.py
@@ -90,9 +90,9 @@ class FilesystemBrowser(QtGui.QDialog):
         self.layout().addLayout(self._footerLayout)
 
     def on_permission_error(self, error):
-        m = QtGui.QMessageBox().warning(
+        self.m = QtGui.QMessageBox().warning(
             self,
-            "permission problems",
+            "Permission problems",
             str(error),
             QtGui.QMessageBox.Cancel
         )

--- a/source/riffle/browser.py
+++ b/source/riffle/browser.py
@@ -89,13 +89,16 @@ class FilesystemBrowser(QtGui.QDialog):
 
         self.layout().addLayout(self._footerLayout)
 
-    def on_model_error(self, error):
+    def on_model_error(self, data):
+        error, item = data
         self.messagebox = QtGui.QMessageBox().warning(
             self,
-            "Permission problems",
+            "Error",
             str(error),
             QtGui.QMessageBox.Cancel
         )
+        self.setLocation(item.path)
+
 
     def _postConstruction(self):
         '''Perform post-construction operations.'''

--- a/source/riffle/browser.py
+++ b/source/riffle/browser.py
@@ -91,14 +91,14 @@ class FilesystemBrowser(QtGui.QDialog):
 
     def on_model_error(self, data):
         error, item = data
-        self.messagebox = QtGui.QMessageBox().warning(
-            self,
-            "Error",
-            str(error),
-            QtGui.QMessageBox.Cancel
-        )
         self.setLocation(item.path)
-
+        #
+        # self.messagebox = QtGui.QMessageBox().warning(
+        #     self,
+        #     "Error",
+        #     str(error),
+        #     QtGui.QMessageBox.Cancel
+        # )
 
     def _postConstruction(self):
         '''Perform post-construction operations.'''

--- a/source/riffle/browser.py
+++ b/source/riffle/browser.py
@@ -67,7 +67,7 @@ class FilesystemBrowser(QtGui.QDialog):
         model = riffle.model.Filesystem(
             path=self._root, parent=self, iconFactory=self._iconFactory
         )
-        model.permission_error.connect(self.on_permission_error)
+        model.model_error.connect(self.on_model_error)
 
         proxy.setSourceModel(model)
         proxy.setDynamicSortFilter(True)
@@ -89,8 +89,8 @@ class FilesystemBrowser(QtGui.QDialog):
 
         self.layout().addLayout(self._footerLayout)
 
-    def on_permission_error(self, error):
-        self.m = QtGui.QMessageBox().warning(
+    def on_model_error(self, error):
+        self.messagebox = QtGui.QMessageBox().warning(
             self,
             "Permission problems",
             str(error),

--- a/source/riffle/browser.py
+++ b/source/riffle/browser.py
@@ -90,12 +90,12 @@ class FilesystemBrowser(QtGui.QDialog):
         self.layout().addLayout(self._footerLayout)
 
     def on_permission_error(self, error):
-        m = QtGui.QMessageBox.warning(self, 
+        m = QtGui.QMessageBox().warning(
+            self,
             "permission problems",
-            error,
-            QMessageBox.Cancel
+            str(error),
+            QtGui.QMessageBox.Cancel
         )
-        m.show()
 
     def _postConstruction(self):
         '''Perform post-construction operations.'''

--- a/source/riffle/model.py
+++ b/source/riffle/model.py
@@ -194,12 +194,11 @@ class Directory(Item):
 
         # List paths under this directory.
         paths = []
-
-        if not os.access(self.path, os.R_OK):
+        try:
+            for name in os.listdir(self.path):
+                paths.append(os.path.normpath(os.path.join(self.path, name)))
+        except (OSError, WindowsError) as error:
             return children
-
-        for name in os.listdir(self.path):
-            paths.append(os.path.normpath(os.path.join(self.path, name)))
 
         # Handle collections.
         collections, remainder = clique.assemble(

--- a/source/riffle/model.py
+++ b/source/riffle/model.py
@@ -194,6 +194,10 @@ class Directory(Item):
 
         # List paths under this directory.
         paths = []
+
+        if not os.access(self.path, os.R_OK):
+            return children
+
         for name in os.listdir(self.path):
             paths.append(os.path.normpath(os.path.join(self.path, name)))
 

--- a/source/riffle/model.py
+++ b/source/riffle/model.py
@@ -10,13 +10,13 @@ from PySide.QtCore import Qt, QAbstractItemModel, QModelIndex, QDir
 from PySide.QtGui import QSortFilterProxyModel
 import clique
 
-# WindowsError do not exist under Linux therefore we need to check in advance 
-# on which platform we are in...
+
+# WindowsError do not exist under Linux
 try:
-    OSException = WindowsError
+    _OSException = WindowsError
 
 except NameError as e:
-    OSException = OSError
+    _OSException = OSError
 
 
 class PermissionError(Exception):
@@ -211,7 +211,7 @@ class Directory(Item):
             for name in os.listdir(self.path):
                 paths.append(os.path.normpath(os.path.join(self.path, name)))
 
-        except OSException as error:
+        except _OSException as error:
             raise PermissionError(error)
 
         # Handle collections.

--- a/source/riffle/model.py
+++ b/source/riffle/model.py
@@ -19,7 +19,7 @@ except NameError as e:
     _OSException = OSError
 
 
-class PermissionError(Exception):
+class ModelError(Exception):
     pass
 
 
@@ -212,7 +212,7 @@ class Directory(Item):
                 paths.append(os.path.normpath(os.path.join(self.path, name)))
 
         except _OSException as error:
-            raise PermissionError(error)
+            raise ModelError(error)
 
         # Handle collections.
         collections, remainder = clique.assemble(
@@ -295,7 +295,7 @@ class Collection(Item):
 
 class Filesystem(QAbstractItemModel):
     '''Model representing filesystem.'''
-    permission_error = QtCore.Signal(object)
+    model_error = QtCore.Signal(object)
     ITEM_ROLE = Qt.UserRole + 1
 
     def __init__(self, path='', parent=None, iconFactory=None):
@@ -498,8 +498,8 @@ class Filesystem(QAbstractItemModel):
             startIndex = len(item.children)
             try:
                 additionalChildren = item.fetchChildren()
-            except PermissionError as error:
-                self.permission_error.emit(error)
+            except ModelError as error:
+                self.model_error.emit(error)
                 additionalChildren = []
 
             endIndex = startIndex + len(additionalChildren) - 1

--- a/source/riffle/model.py
+++ b/source/riffle/model.py
@@ -500,7 +500,8 @@ class Filesystem(QAbstractItemModel):
                 additionalChildren = item.fetchChildren()
             except PermissionError as error:
                 self.permission_error.emit(error)
-            
+                additionalChildren = []
+
             endIndex = startIndex + len(additionalChildren) - 1
             if endIndex >= startIndex:
                 self.beginInsertRows(index, startIndex, endIndex)

--- a/source/riffle/model.py
+++ b/source/riffle/model.py
@@ -499,8 +499,8 @@ class Filesystem(QAbstractItemModel):
             try:
                 additionalChildren = item.fetchChildren()
             except ModelError as error:
-                self.model_error.emit(error)
-                additionalChildren = []
+                self.model_error.emit((error, item.parent))
+                return
 
             endIndex = startIndex + len(additionalChildren) - 1
             if endIndex >= startIndex:

--- a/source/riffle/model.py
+++ b/source/riffle/model.py
@@ -3,14 +3,25 @@
 # :license: See LICENSE.txt.
 
 import os
+import sys
 from datetime import datetime
 from PySide import QtCore
 from PySide.QtCore import Qt, QAbstractItemModel, QModelIndex, QDir
 from PySide.QtGui import QSortFilterProxyModel
 import clique
 
+# WindowsError do not exist under Linux therefore we need to check in advance 
+# on which platform we are in...
+try:
+    OSException = WindowsError
+
+except NameError as e:
+    OSException = OSError
+
+
 class PermissionError(Exception):
     pass
+
 
 def ItemFactory(path):
     '''Return appropriate :py:class:`Item` instance for *path*.
@@ -199,7 +210,8 @@ class Directory(Item):
         try:
             for name in os.listdir(self.path):
                 paths.append(os.path.normpath(os.path.join(self.path, name)))
-        except (OSError, WindowsError) as error:
+
+        except OSException as error:
             raise PermissionError(error)
 
         # Handle collections.


### PR DESCRIPTION
Added check to see whether the folder we are trying to access has the rights to be read.
This stop riffle from throwing a OSError exception.